### PR TITLE
feat: expose FP16 acceleration setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decky-lsfg-vk",
-  "version": "0.12.6",
+  "version": "0.12.7",
   "description": "Use Lossless Scaling on the Steam Deck using the lsfg-vk vulkan layer",
   "type": "module",
   "scripts": {

--- a/py_modules/lsfg_vk/config_schema.py
+++ b/py_modules/lsfg_vk/config_schema.py
@@ -178,7 +178,7 @@ class ConfigurationManager:
             "profiles": {DEFAULT_PROFILE_NAME: config},
             "global_config": {
                 "dll": config.get("dll", ""),
-                "no_fp16": False  # Always enabled even if previously set
+                "no_fp16": config.get("no_fp16", False)
             }
         }
         return ConfigurationManager.generate_toml_content_multi_profile(profile_data)
@@ -188,7 +188,7 @@ class ConfigurationManager:
         """Generate TOML configuration file content with multiple profiles"""
         lines = ["version = 1"]
         lines.append("")
-        
+
         # Add global section with global fields
         lines.append("[global]")
         
@@ -202,10 +202,11 @@ class ConfigurationManager:
         if dll_path:
             lines.append(f"# specify where Lossless.dll is stored")
             lines.append(f'dll = "{dll_path}"')
-            lines.append("")
-            
+        lines.append("")
+
         lines.append(f"# FP16 acceleration")
-        lines.append(f"no_fp16 = false")
+        no_fp16 = bool(profile_data["global_config"].get("no_fp16", False))
+        lines.append(f"no_fp16 = {str(no_fp16).lower()}")
         lines.append("")
         
         # Add game sections for each profile
@@ -339,8 +340,7 @@ class ConfigurationManager:
                         elif key == "dll":
                             global_config["dll"] = value
                         elif key == "no_fp16":
-                            # Always enforce FP16 to be enabled (no_fp16 = false)
-                            global_config["no_fp16"] = False
+                            global_config["no_fp16"] = value.lower() in ('true', '1', 'yes', 'on')
                     
                     # Handle game section
                     elif in_game_section:

--- a/src/components/ConfigurationSection.tsx
+++ b/src/components/ConfigurationSection.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect } from "react";
 import { RiArrowDownSFill, RiArrowUpSFill } from "react-icons/ri";
 import { ConfigurationData } from "../config/configSchema";
 import {
-  FLOW_SCALE, PERFORMANCE_MODE, HDR_MODE,
+  FLOW_SCALE, NO_FP16, PERFORMANCE_MODE, HDR_MODE,
   EXPERIMENTAL_PRESENT_MODE, DXVK_FRAME_RATE, DISABLE_STEAMDECK_MODE,
   MANGOHUD_WORKAROUND, DISABLE_VKBASALT, FORCE_ENABLE_VKBASALT, ENABLE_WSI, ENABLE_ZINK
 } from "../config/generatedConfigSchema";
@@ -122,6 +122,15 @@ export function ConfigurationSection({
               max={1.0}
               step={0.01}
               onChange={(value) => onConfigChange(FLOW_SCALE, value)}
+            />
+          </PanelSectionRow>
+
+          <PanelSectionRow>
+            <ToggleField
+              label="FP16 Acceleration"
+              description="Use FP16 shaders when supported; disable this on older NVIDIA GPUs if needed"
+              checked={!config.no_fp16}
+              onChange={(value) => onConfigChange(NO_FP16, !value)}
             />
           </PanelSectionRow>
 

--- a/src/components/ConfigurationSection.tsx
+++ b/src/components/ConfigurationSection.tsx
@@ -128,7 +128,7 @@ export function ConfigurationSection({
           <PanelSectionRow>
             <ToggleField
               label="FP16 Acceleration"
-              description="Use FP16 shaders when supported; disable this on older NVIDIA GPUs if needed"
+              description="Use FP16 shaders when supported"
               checked={!config.no_fp16}
               onChange={(value) => onConfigChange(NO_FP16, !value)}
             />


### PR DESCRIPTION
## Summary

- Expose FP16 acceleration as a Decky toggle, enabled by default.
- Preserve the existing `no_fp16` setting when reading and writing `conf.toml` instead of forcing it to `false`.
- Bump the plugin version from `0.12.6` to `0.12.7`.

## Validation

- Verified TOML round-tripping with FP16 enabled and disabled.
- `npm run build`
